### PR TITLE
feat: notification limits per app

### DIFF
--- a/hydepanel.schema.json
+++ b/hydepanel.schema.json
@@ -618,33 +618,34 @@
               "type": "string"
             }
           },
-          "$ref": "#/definitions/anchor",
+          "anchor": {
+            "$ref": "#/definitions/anchor"
+          },
           "auto_dismiss": {
             "type": "boolean"
           },
           "timeout": {
             "type": "integer"
           },
-          "count": {
-            "type": "integer"
+          "max_count": {
+            "type": "integer",
+            "description": "Maximum total number of notifications to keep across all apps"
+          },
+          "per_app_limits": {
+            "type": "object",
+            "description": "Maximum number of notifications to keep per specific app",
+            "patternProperties": {
+              "^.*$": {
+                "type": "integer",
+                "description": "Maximum number of notifications to keep for this app"
+              }
+            }
           },
           "play_sound": {
             "type": "boolean"
           },
-          "sound_fie": {
-            "type": "string",
-            "enum": [
-              "notification1",
-              "notification2",
-              "notification3",
-              "notification4",
-              "notification5",
-              "notification6",
-              "notification7",
-              "notification8",
-              "notification9",
-              "notification10"
-            ]
+          "sound_file": {
+            "type": "string"
           }
         }
       },

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -158,8 +158,9 @@ DEFAULT_CONFIG = {
         "ignored": [],
         "timeout": 3000,
         "max_count": 200,
+        "per_app_limits": {},
         "play_sound": False,
-        "sound_file": "notification4",
+        "sound_file": "notification4"
     },
     "osd": {
         "enabled": True,


### PR DESCRIPTION
### Description
A pass on implementing a limit per app_name in addition to the max_count. 
So this would find and remove the oldest notification from the same app when it's exceeding a set count for it, allowing something like Spotify to only ever display the latest, or maybe two last songs without filling up the notification list on its own. Prioritizes maintaining the app count first, so if the max_count would be exceeded and oldest one removed, it can instead remove the oldest of a specific app if that is what would be the exceeding notification.

_I'm not sure if this is the best approach to it, but it seems to work fine, it might be a bit more processing needed_


Added to notifications is this new **per_app_limits**;
```json
    "per_app_limits": {
      "Spotify": 1,
      "HyDE Power": 2
    },
    ```