### PR TITLE
feat: workspace label formatting & unoccupied class

### DIFF
--- a/hydepanel.schema.json
+++ b/hydepanel.schema.json
@@ -313,7 +313,8 @@
       "type": "object",
       "properties": {
         "count": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1
         },
         "hide_unoccupied": {
           "type": "boolean"
@@ -323,6 +324,18 @@
         },
         "empty_scroll": {
           "type": "boolean"
+        },
+        "icon_map": {
+          "type": "object",
+          "description": "Map workspace IDs to custom labels or icons. Keys are workspace IDs, values are the labels/icons",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "default_label_format": {
+          "type": "string",
+          "description": "Format for workspace labels when not in icon_map. Use '{id}' for workspace number, or any other string/icon",
+          "default": "{id}"
         },
         "ignored": {
           "type": "array",

--- a/styles/workspace.scss
+++ b/styles/workspace.scss
@@ -2,7 +2,9 @@
 @use "common/functions.scss";
 @use "variable.scss";
 
-$workspace-transition: all 0.2s ease-in-out;
+$workspace-transition:
+  padding 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+  background-color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
 
 /** workspace switcher widget */
 
@@ -14,8 +16,7 @@ $workspace-transition: all 0.2s ease-in-out;
     padding: functions.toEm(2) 0.5em;
     transition: $workspace-transition;
     border-radius: variable.$radius-large;
-    background-color: transparent;
-    transition-delay: 200ms;
+    background-color: theme.$background;
 
     label {
       color: theme.$text-main;
@@ -40,6 +41,14 @@ $workspace-transition: all 0.2s ease-in-out;
 
       & > label {
         color: theme.$background-dark;
+      }
+    }
+
+    &.unoccupied {
+      opacity: 0.5;
+
+      &:hover {
+        opacity: 1;
       }
     }
   }

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -238,7 +238,12 @@ DEFAULT_CONFIG = {
         "ignored": [-99],
         "reverse_scroll": False,
         "empty_scroll": False,
-        "icon_map": {},
+        "default_label_format": "{id}",
+        "icon_map": {
+            "1": "1",
+            "2": "2",
+            "3": "3"
+        },
     },
 }
 


### PR DESCRIPTION
### Description
Extended the icon mapping for workspaces a little bit for default behaviour in formatting.
There was also a bit of odd behaviour with the ignore array not actually ignoring workspaces, so this resolved that as well.

Also implemented ``notify::empty`` to add and remove a unoccupied class for further styling empty workspaces that aren't hidden. For now just a lower opacity in styling.
![image](https://github.com/user-attachments/assets/ff732aca-dd54-4255-9e76-5af033743387)


```jsonc
    "workspaces": {
      ...
      "default_label_format": "{id}", // Default for labels when not in icon_map
      "icon_map": {
        "1": "", // Uses an icon instead of the workspace number
        "2": " Text", // Mix icon and text
        "3": " " // blank space for just an indicator look
      }
    }