### PR TITLE
feat: language support for OCR with swicther

### DIFF
--- a/assets/scripts/ocr.sh
+++ b/assets/scripts/ocr.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
+# Language argument (default to eng)
+LANG="${1:-eng}"
+
 # Optional slurp arguments
-SLURP_ARGS="${1:-}"
+SLURP_ARGS="${2:-}"
 
 # Temporary file name
 TMP_IMG="tmp.png"
 
 # Select area with slurp and capture with grim
 grim -g "$(slurp $SLURP_ARGS)" "$TMP_IMG" && \
-tesseract -l eng "$TMP_IMG" - | wl-copy && \
-
+tesseract -l $LANG "$TMP_IMG" - | wl-copy
 
 if [ -f "${TMP_IMG}" ]; then
-    notify-send -a "Hydepanel" -i "${full_path}" "OCR Success" "Text Copied to Clipboard"
+    notify-send -a "Hydepanel" "OCR Success" "Text Copied to Clipboard (${LANG})"
 else
     notify-send -a "Hydepanel" "OCR Aborted"
 fi

--- a/styles/common/common.scss
+++ b/styles/common/common.scss
@@ -338,3 +338,29 @@ scrollbar {
   background-size: contain;
   margin: functions.toEm(3) functions.toEm(10) functions.toEm(3) 0;
 }
+
+// Menu styling
+menu#ocr-menu {
+  padding: 0.5em;
+
+  menuitem {
+    padding: 0.5em 1em;
+
+    &:hover {
+      background-color: theme.$surface-neutral;
+
+      label#ocr-menu-item {
+        color: theme.$background-dark;
+      }
+    }
+
+    label#ocr-menu-item {
+      color: theme.$surface-highlight;
+
+      &.selected {
+        font-weight: bold;
+        color: theme.$accent-light;
+      }
+    }
+  }
+}

--- a/widgets/ocr.py
+++ b/widgets/ocr.py
@@ -1,25 +1,74 @@
+import subprocess
+
 from fabric.utils import exec_shell_command_async, get_relative_path
+from gi.repository import Gdk, Gtk
 
 from shared.widget_container import ButtonWidget
 from utils.widget_settings import BarConfig
 
 
 class OCRWidget(ButtonWidget):
-    """A widget to pick a color."""
+    """A widget that provides Optical Character Recognition functionality.
+
+    Left-click to select an area and copy recognized text to clipboard.
+    Right-click to select the OCR language from available tesseract language packs.
+    """
 
     def __init__(self, widget_config: BarConfig, bar, **kwargs):
         super().__init__(name="ocr", **kwargs)
-
         self.config = widget_config["ocr"]
+        self.current_lang = "eng"  # default
+        self.script_file = get_relative_path("../assets/scripts/ocr.sh")
 
         self.set_label(f"{self.config['icon']}")
 
+        # Left click for OCR
         self.connect(
             "button-press-event",
-            lambda *_: exec_shell_command_async(f"{self.script_file}", lambda *_: None),
+            self.on_button_press
         )
 
-        self.script_file = get_relative_path("../assets/scripts/ocr.sh")
-
         if self.config["tooltip"]:
-            self.set_tooltip_text("Click to ocr")
+            self.set_tooltip_text("Left click to OCR, right click to select language")
+
+    def on_button_press(self, _, event):
+        if event.button == 3:  # Right click
+            self.show_language_menu()
+        else:  # Left click
+            exec_shell_command_async(
+                f"{self.script_file} {self.current_lang}",
+                lambda *_: None
+            )
+
+    def show_language_menu(self):
+        menu = Gtk.Menu()
+        menu.set_name("ocr-menu")  # For CSS targeting
+
+        # Get available languages
+        langs = self.get_available_languages()
+
+        for lang in langs:
+            if lang != "osd":  # Skip the OSD option
+                item = Gtk.MenuItem(label=lang)
+                label = item.get_child()
+                label.set_name("ocr-menu-item")  # For CSS targeting
+                if lang == self.current_lang:
+                    label.get_style_context().add_class("selected")
+                item.connect("activate", self.on_language_selected, lang)
+                menu.append(item)
+
+        menu.show_all()
+        menu.popup_at_widget(self, Gdk.Gravity.SOUTH, Gdk.Gravity.NORTH, None)
+
+    def get_available_languages(self):
+        # Run the command synchronously to get output
+        try:
+            result = subprocess.check_output(["tesseract", "--list-langs"], text=True)
+            # Skip first line (header) and filter empty lines
+            return [lang.strip() for lang in result.split('\n')[1:] if lang.strip()]
+        except subprocess.CalledProcessError:
+            return ["eng"]  # fallback to English if command fails
+
+    def on_language_selected(self, _, lang):
+        self.current_lang = lang
+        self.set_tooltip_text(f"OCR ({lang})")


### PR DESCRIPTION
Adds lang argument to the script, and reworks the widget to include a context menu on rightclicking to list available language packes and select them.


_This could possibly be extended to not enable the menu if no other language packs are found for better QoL?_