### PR TITLE
Improve audio controls with per-application sliders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,6 @@ pyrightconfig.json
 styles/theme.scss
 
 todo.md
+config.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python

--- a/config.json
+++ b/config.json
@@ -83,7 +83,7 @@
       "style_classes": ["compact"]
     },
     {
-      "widgets": ["quick_settings", "cpu", "network_usage"],
+      "widgets": ["quick_settings"],
       "spacing": 0,
       "style_classes": ["compact"]
     }

--- a/widgets/quick_settings/quick_settings.py
+++ b/widgets/quick_settings/quick_settings.py
@@ -32,6 +32,7 @@ from widgets.quick_settings.togglers import (
 
 from .sliders import AudioSlider, BrightnessSlider, MicrophoneSlider
 from .submenu import (
+    AudioSubMenu,
     BluetoothSubMenu,
     BluetoothToggle,
     PowerProfileSubMenu,
@@ -252,6 +253,9 @@ class QuickSettingsMenu(Box):
             vexpand=True,
         )
 
+        # Add audio submenu
+        self.audio_submenu = AudioSubMenu()
+
         # Add sliders to the grid in a single column
         sliders_grid.attach(BrightnessSlider(), 0, 0, 1, 1)
         sliders_grid.attach(AudioSlider(), 0, 1, 1, 1)
@@ -285,7 +289,7 @@ class QuickSettingsMenu(Box):
             orientation="v",
             spacing=10,
             style_classes=[slider_class],
-            children=(sliders_grid,),
+            children=(sliders_grid, self.audio_submenu),
             h_expand=True,
         )
 

--- a/widgets/quick_settings/sliders/audio.py
+++ b/widgets/quick_settings/sliders/audio.py
@@ -1,30 +1,93 @@
+
 from services import audio_service
 from shared.setting_scale import SettingSlider
 from utils.icons import icons
 
 
 class AudioSlider(SettingSlider):
-    """A widget to display a scale for audio settings."""
+    """A widget to display a scale for audio settings.
 
-    def __init__(self):
+    Can be used for both device audio and application audio control.
+    """
+
+    def __init__(self, audio_stream=None):
+        """Initialize the audio slider.
+
+        Args:
+            audio_stream: Optional AudioStream object. If None, controls device audio.
+                        If provided, controls application-specific audio.
+        """
         self.client = audio_service
-        super().__init__(icon_name=icons["audio"]["volume"]["high"])
+        self.audio_stream = audio_stream
+
+        # Initialize with default values first
+        super().__init__(
+            icon_name=icons["audio"]["volume"]["high"],
+            start_value=0
+        )
+
+        if not audio_stream:
+            def init_device_audio(*args):
+                if not self.client.speaker:
+                    return
+                self.audio_stream = self.client.speaker
+                self.update_state()
+                self.client.disconnect_by_func(init_device_audio)
+                self.client.connect("speaker-changed", self.on_audio_change)
+
+            self.client.connect("changed", init_device_audio)
+            if self.client.speaker:
+                init_device_audio()
+        else:
+            self.update_state()
+            self.audio_stream.connect("changed", self.on_audio_change)
+
+        # Connect signals
         self.scale.connect("change-value", self.on_scale_move)
-        self.client.connect("speaker-changed", self.on_speaker_change)
-        self.icon_button.connect("clicked", self.on_button_click)
+        if not audio_stream:
+            self.icon_button.connect("button-press-event", self.on_button_click)
+        else:
+            self.icon_button.connect("clicked", self.on_mute_click)
+
+    def _get_icon_name(self):
+        """Get the appropriate icon name based on mute state."""
+        if not self.audio_stream:
+            return icons["audio"]["volume"]["high"]
+        return icons["audio"]["volume"]["muted" if self.audio_stream.muted else "high"]
+
+    def update_state(self):
+        """Update the slider state from the audio stream."""
+        if not self.audio_stream:
+            return
+
+        self.scale.set_sensitive(not self.audio_stream.muted)
+        self.scale.set_value(self.audio_stream.volume)
+        self.scale.set_tooltip_text(f"{round(self.audio_stream.volume)}%")
+        self.icon.set_from_icon_name(self._get_icon_name(), 20)
 
     def on_scale_move(self, _, __, moved_pos):
-        self.client.speaker.volume = moved_pos
+        """Handle volume slider changes."""
+        if self.audio_stream:
+            self.audio_stream.volume = moved_pos
 
-    def on_speaker_change(self, *args):
-        self.scale.set_sensitive(not audio_service.speaker.muted)
-        self.scale.set_value(audio_service.speaker.volume)
-        self.scale.set_tooltip_text(f"{round(audio_service.speaker.volume)}%")
+    def on_audio_change(self, *args):
+        """Update slider state when audio changes."""
+        self.update_state()
 
-    def on_button_click(self, *_):
-        self.client.speaker.muted = not self.client.speaker.muted
-        self.icon.set_from_icon_name(
-            icons["audio"]["volume"]["muted"], 20
-        ) if self.client.speaker.muted else self.icon.set_from_icon_name(
-            icons["audio"]["volume"]["high"], 20
-        )
+    def on_button_click(self, button, event):
+        """Handle button clicks on the icon button."""
+        if event.button == 3:  # Right click
+            # Find and toggle the AudioSubMenu
+            parent = self.get_parent()
+            while parent and not hasattr(parent, "audio_submenu"):
+                parent = parent.get_parent()
+
+            if parent and hasattr(parent, "audio_submenu"):
+                parent.audio_submenu.toggle_reveal()
+        else:  # Left click
+            self.on_mute_click(button)
+
+    def on_mute_click(self, button):
+        """Toggle mute state."""
+        if self.audio_stream:
+            self.audio_stream.muted = not self.audio_stream.muted

--- a/widgets/quick_settings/submenu/__init__.py
+++ b/widgets/quick_settings/submenu/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F403
+from .audio import *
 from .bluetooth import *
 from .power import *
 from .wifi import *

--- a/widgets/quick_settings/submenu/audio.py
+++ b/widgets/quick_settings/submenu/audio.py
@@ -1,0 +1,123 @@
+from fabric.widgets.box import Box
+from fabric.widgets.image import Image
+from fabric.widgets.label import Label
+from fabric.widgets.scrolledwindow import ScrolledWindow
+from gi.repository import Gtk
+
+from services import audio_service
+from shared.submenu import QuickSubMenu
+from shared.widget_container import HoverButton
+from utils.icons import icons
+from widgets.quick_settings.sliders.audio import AudioSlider
+
+
+class AudioSubMenu(QuickSubMenu):
+    """A submenu to display application-specific audio controls."""
+
+    def __init__(self, **kwargs):
+        self.client = audio_service
+
+        # Create refresh button first since parent needs it
+        self.scan_button = HoverButton(
+            style_classes="submenu-button",
+            name="refresh-button",
+            image=Image(
+                icon_name=icons["audio"]["volume"]["high"],
+                icon_size=18
+            )
+        )
+        self.scan_button.connect("clicked", lambda _: self.update_apps())
+
+        # Create app list container
+        self.app_list = Gtk.ListBox(
+            selection_mode=Gtk.SelectionMode.NONE,
+            name="app-list"
+        )
+        self.app_list.get_style_context().add_class("menu")
+
+        # Wrap in scrolled window
+        self.child = ScrolledWindow(
+            min_content_size=(-1, 190),
+            max_content_size=(-1, 190),
+            propagate_width=True,
+            propagate_height=True,
+            child=self.app_list,
+        )
+
+        # Initialize parent with our components
+        super().__init__(
+            title="Application Audio",
+            title_icon=icons["audio"]["volume"]["high"],
+            scan_button=self.scan_button,
+            child=Box(orientation="v", children=[self.child]),
+            **kwargs,
+        )
+
+        # Connect signals
+        self.client.connect("changed", self.update_apps)
+        self.update_apps()
+
+    def update_apps(self, *args):
+        """Update the list of applications with volume controls."""
+        # Clear existing rows
+        while (row := self.app_list.get_row_at_index(0)):
+            self.app_list.remove(row)
+
+        # Add applications
+        for app in self.client.applications:
+            row = Gtk.ListBoxRow()
+            row.get_style_context().add_class("menu-item")
+
+            # Main container
+            box = Box(
+                orientation="v",
+                spacing=6,
+                margin_start=6,
+                margin_end=6,
+                margin_top=3,
+                margin_bottom=3
+            )
+
+            # App name
+            name_box = Box(
+                orientation="h",
+                spacing=12,
+                h_expand=True
+            )
+
+            # App icon
+            icon = Image(
+                icon_name=app.icon_name or icons["audio"]["volume"]["high"],
+                icon_size=18
+            )
+            name_box.pack_start(icon, False, True, 0)
+
+            # App name label
+            name_label = Label(
+                label=app.name,
+                style_classes="submenu-item-label"
+            )
+            name_label.set_ellipsize(3)  # PANGO_ELLIPSIZE_END
+            name_label.set_halign(Gtk.Align.START)
+            name_label.set_tooltip_text(app.description or app.name)
+            name_box.pack_start(name_label, True, True, 0)
+
+            box.add(name_box)
+
+            # Audio controls
+            audio_box = Box(
+                orientation="h",
+                spacing=6,
+                margin_start=24  # Indent to align with app name
+            )
+
+            # Create audio slider for this app
+            slider = AudioSlider(app)
+            audio_box.pack_start(slider, True, True, 0)
+
+            box.add(audio_box)
+
+            row.add(box)
+            self.app_list.add(row)
+
+        self.app_list.show_all()


### PR DESCRIPTION
- Made AudioSlider reusable for both device and app audio
- Added per-application volume controls in AudioSubMenu, to surface basic mixer functionality
- Toggle new submenu by right-clicking the audio icon (maybe changing this?)

Though, this is more of a draft atm, need another pair of eyes on two things, one which was previously present.
1. Grabbing and dragging the slider for device volume and brightness have been "dropping" initial click to drag, requiring you to click then immidiately click again to drag, essentially it need to enter a modify state before it lets you adjust, which it is when the OSD shows up.

2. At this point, the application slider is working just fine, but it is logging a lot of;
gtk_adjustment_get_lower: assertion 'GTK_IS_ADJUSTMENT (adjustment)' failed
gtk_adjustment_set_value: assertion 'GTK_IS_ADJUSTMENT (adjustment)' failed


https://github.com/user-attachments/assets/69ad416b-20ac-4e3e-bb57-d2d8b70be2cd


_(also need to adjust the css again as the slider is nested with more padding than the other sliders)_
